### PR TITLE
Fix 404 not found header when accessing pagination

### DIFF
--- a/10-Pagination.php
+++ b/10-Pagination.php
@@ -77,6 +77,9 @@ class Pagination extends AbstractPicoPlugin {
 
 	public function onPageRendering(&$twig, &$twigVariables, &$templateName)
 	{
+		// Override 404 header
+		header($_SERVER['SERVER_PROTOCOL'].' 200 OK');
+
 		// Set a bunch of view vars
 
 		// send the paged pages in separate var


### PR DESCRIPTION
And rename pagination.php to 10-Pagination.php following Pico v1 conventions
for plugins.