### PR TITLE
Support any valid date format when sorting pages

### DIFF
--- a/10-Pagination.php
+++ b/10-Pagination.php
@@ -5,7 +5,7 @@
  * @author Andrew Meyer
  * @link http://rewdy.com
  * @license http://opensource.org/licenses/MIT
- * @version 1.6
+ * @version 1.7
  */
 class Pagination extends AbstractPicoPlugin {
 	

--- a/10-Pagination.php
+++ b/10-Pagination.php
@@ -59,8 +59,8 @@ class Pagination extends AbstractPicoPlugin {
 		// get total pages before show_pages is sliced
 		$this->total_pages = ceil(count($show_pages) / $this->config['limit']);
 		// sort $show_pages by $page['date']:
-		$pdate = array_column($show_pages, 'date');
-		array_multisort($pdate, SORT_DESC, $show_pages);
+		$pdate = array_map('strtotime', array_column($show_pages, 'date'));
+		array_multisort($pdate, SORT_DESC, SORT_NUMERIC, $show_pages);
 		// slice show_pages to the limit
 		$show_pages = array_slice($show_pages, $this->offset, $this->config['limit']);
 		// set filtered pages to paged_pages

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@ Provides basic pagination for [Pico](http://pico.dev7studios.com).
 
 ## Changelog
 
+**1.7** - Changed date sorting to allow the use of any PHP valid date format
 **1.6** - Fixed a sorting issue when using subfolders.
 **1.5** - Added `next_page_url` and `prev_page_url` variables for Twig. Preparing to stop returning markup from the plugin in a future release—plugin should only return data and leave theming up to site builders.
 **1.4** - Changed to use of `&gt;/&lt;` in default next_text and prev_text variables and added more variables Google search-like numbered pagination.  


### PR DESCRIPTION
## Feature this adds
This implementation of date sorting allows any of the valid php date formats, ie users can choose the format in the page's date meta header. Inspired by https://stackoverflow.com/questions/56191959/php-using-array-multisort-to-sort-multiple-arrays-by-date


## Bug this fixes
<!-- Please include reference to the issue is one exists. Leave blank for N/A. -->


## PR Checklist

_Please make sure the following tasks have been completed_

- [x] I have tested existing behavior to check for regressions  
- [x] I have bumped the version number  
- [x] I have updated the CHANGELOG (in the readme) referencing the new version number
